### PR TITLE
Drain mode Feature

### DIFF
--- a/CONSUMER_DRAIN_CONTROL.md
+++ b/CONSUMER_DRAIN_CONTROL.md
@@ -32,7 +32,7 @@ This fork introduces an explicit **"drain mode"** to address these scenarios by 
 **How the Draining Mechanism Relates and Its Benefits**:
 
 - **Preventing Operational-Induced Redeliveries**: The primary benefit of the drain mode is to **minimize message redeliveries that are a direct consequence of the operational procedure itself** (e.g., dynamic configuration updates, graceful shutdowns, etc.). It does not solve all redelivery scenarios. During such operations, _without controlled draining_ messages residing in client buffers (both the application's `MessageChannel` and the client's internal `queueCh`) might not be fully processed and ACKed, when a consumer is stopped or its processing logic changes mid-flight. These become unacknowledged from the broker's perspective and will be redelivered. _With this fork's `EnterDrainMode()`_:
-  - The application explicitly command the client to stop sending new message permits from the broker, even if buffered messages are being acknowledged.
+  - The application explicitly command the client to stop requesting new message permits from the broker, even if buffered messages are being acknowledged.
   - This allows the application to safely process and acknowledge every message that has already been fetched by the client and is residing in its buffers.
   - This significantly reduces the pool of messages that would otherwise become unacknowledged (and thus redelivered) due to the shutdown or rule change itself.
 - **Supporting Overall Orderliness for Keyed Messages During Operations**:
@@ -48,3 +48,102 @@ Beyond addressing redelivery concerns, drain mode provides some operational adva
 - **Horizontally Scaled Environments**: Supports more predictable behavior and cleaner state transitions during deployments, scaling events, or rule updates, particularly valuable in containerized or auto-scaled deployments.
 
 The need for **idempotent message processing logic in the application remains absolutely crucial** for robustly handling all types of redelivery scenarios that can occur in a distributed messaging system. This "drain mode" assists in making planned operational procedures smoother and less prone to causing unnecessary redeliveries.
+
+## API Usage
+
+The drain mode feature is available on both the `Consumer` and `Reader` interfaces through two methods:
+
+```go
+// Consumer interface
+func (c *consumer) EnterDrainMode() error
+func (c *consumer) ExitDrainMode() error
+
+// Reader interface (which wraps a Consumer)
+func (r *reader) EnterDrainMode() error
+func (r *reader) ExitDrainMode() error
+```
+
+### Example: Rule Change with Drain Mode
+
+```go
+// When processing logic/rules need to be updated:
+func updateConsumerRules(consumer pulsar.Consumer) error {
+    // 1. Enter drain mode to stop receiving new messages from broker
+    if err := consumer.EnterDrainMode(); err != nil {
+        return fmt.Errorf("failed to enter drain mode: %w", err)
+    }
+
+    // 2. Process all messages already in client buffers with current rules
+    for {
+        ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+        msg, err := consumer.Receive(ctx)
+        cancel()
+
+        if err != nil {
+            // No more messages in buffer
+            break
+        }
+
+        // Process with current rules
+        processMessageWithCurrentRules(msg)
+        consumer.Ack(msg)
+    }
+
+    // 3. Update processing rules
+    updateRules()
+
+    // 4. Resume normal message flow with new rules
+    if err := consumer.ExitDrainMode(); err != nil {
+        return fmt.Errorf("failed to exit drain mode: %w", err)
+    }
+
+    return nil
+}
+```
+
+### Example: Graceful Shutdown with Drain Mode
+
+```go
+// For graceful application shutdown:
+func performGracefulShutdown(consumer pulsar.Consumer, shutdownTimeout time.Duration) {
+    // 1. Enter drain mode to stop receiving new messages from broker
+    if err := consumer.EnterDrainMode(); err != nil {
+        log.Printf("Warning: Failed to enter drain mode: %v", err)
+    }
+
+    // 2. Set a deadline for processing remaining messages
+    ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+    defer cancel()
+
+    // 3. Process remaining buffered messages until deadline
+    for {
+        receiveCtx, receiveCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+        msg, err := consumer.Receive(receiveCtx)
+        receiveCancel()
+
+        if err != nil {
+            // Either no more messages or shutdown deadline reached
+            break
+        }
+
+        // Process and acknowledge message
+        processMessage(msg)
+        consumer.Ack(msg)
+    }
+
+    // 4. Close the consumer
+    consumer.Close()
+
+    log.Println("Consumer shutdown gracefully")
+}
+```
+
+## Metrics
+
+To help monitor and track the usage of drain mode, the following metrics have been added:
+
+- `pulsar_client_consumers_in_drain_mode`: A gauge that tracks the number of consumers currently in drain mode.
+- `pulsar_client_drain_mode_entered`: A counter that increments every time a consumer enters drain mode.
+- `pulsar_client_drain_mode_exited`: A counter that increments every time a consumer exits drain mode.
+
+These metrics follow the same labeling patterns as other Pulsar client metrics, with labels added based on the configured `MetricsCardinality` (tenant, namespace, topic).

--- a/CONSUMER_DRAIN_CONTROL.md
+++ b/CONSUMER_DRAIN_CONTROL.md
@@ -16,8 +16,8 @@ The standard client behavior can lead to new messages being fetched as buffered 
 
 #### Benefits of this Enhanced Drain Control
 
-1. **Precise Inflow Stoppage**: Guarantees that no new messages are pulled from the broker while the consumer is in "drain mode," even as buffered messages are acknowledged.
+1. **Precise Inflow Stoppage**: Guarantees that no new messages are pulled from the broker while the consumer is in "drain mode", even as buffered messages are acknowledged.
 2. **Complete Processing of Buffered Messages**: Facilitates the full processing of messages already residing in the application's `MessageChannel` and the client's internal `queueCh`.
-3. **Minimized Operational Redeliveries**: By cleanly processing buffered messages before state changes (dynamic reconfiguration, shutdowns), it reduces the chances of messages being NACKed or becoming unacknowledged due to the operation itself, thereby minimizing operationally-induced redeliveries. This supports overall message processing order for a given key.
+3. **Minimized Operational Redeliveries**: By cleanly processing buffered messages before state changes (dynamic reconfiguration, shutdowns), it reduces the chances of messages being NACKed or becoming unacknowledged due to the operation itself, thereby _minimizing operationally-induced redeliveries_. This _supports overall message processing order_ for a given key.
 4. **`Key_Shared` Stickiness Support**: Aims to maintain `Key_Shared` subscription stickiness during the drain period by keeping the underlying connection to the broker alive, even though new message flow is paused. This is particularly important for ensuring keys are not prematurely reassigned during short operational pauses. [Not sure if this is necessary. Will need to test and validate this behavior.]
 5. **Predictable Shutdowns/Updates**: Enables more deterministic behavior during deployments, scaling events, or rule updates in distributed environments.

--- a/CONSUMER_DRAIN_CONTROL.md
+++ b/CONSUMER_DRAIN_CONTROL.md
@@ -1,0 +1,23 @@
+# Enhancing Consumer Drain Control
+
+## Introduction
+
+This fork of the official Apache Pulsar Go client introduces enhanced capabilities for controlling consumer message flow, specifically by adding a "drain mode." This mode allows applications to temporarily stop the ingestion of new messages from the Pulsar broker while ensuring that all messages already buffered within the client (both in the application-facing channel and the client's internal queues) can be processed and acknowledged.
+
+#### Rationale for Drain Mode
+
+The standard Pulsar Go client's permit-based flow control is designed for continuous consumption. When an application needs to perform certain operations like dynamic configuration changes, maintenance, graceful shutdowns while scaling downespecially in horizontally scaled environments like Kubernetes), it's often desirable to:
+
+1. Stop accepting _new_ messages for a specific consumer or all consumers on a client.
+2. Process and acknowledge all messages that have already been delivered and buffered by the client.
+3. Resume normal consumption after necessary operations are completed or cleanly close the consumer.
+
+The standard client behavior can lead to new messages being fetched as buffered ones are acknowledged due to permit renewal. This fork addresses this by providing explicit control to pause new permit requests during such draining operations.
+
+#### Benefits of this Enhanced Drain Control
+
+1. **Precise Inflow Stoppage**: Guarantees that no new messages are pulled from the broker while the consumer is in "drain mode," even as buffered messages are acknowledged.
+2. **Complete Processing of Buffered Messages**: Facilitates the full processing of messages already residing in the application's `MessageChannel` and the client's internal `queueCh`.
+3. **Minimized Operational Redeliveries**: By cleanly processing buffered messages before state changes (dynamic reconfiguration, shutdowns), it reduces the chances of messages being NACKed or becoming unacknowledged due to the operation itself, thereby minimizing operationally-induced redeliveries. This supports overall message processing order for a given key.
+4. **`Key_Shared` Stickiness Support**: Aims to maintain `Key_Shared` subscription stickiness during the drain period by keeping the underlying connection to the broker alive, even though new message flow is paused. This is particularly important for ensuring keys are not prematurely reassigned during short operational pauses. [Not sure if this is necessary. Will need to test and validate this behavior.]
+5. **Predictable Shutdowns/Updates**: Enables more deterministic behavior during deployments, scaling events, or rule updates in distributed environments.

--- a/CONSUMER_DRAIN_CONTROL.md
+++ b/CONSUMER_DRAIN_CONTROL.md
@@ -2,22 +2,49 @@
 
 ## Introduction
 
-This fork of the official Apache Pulsar Go client introduces enhanced capabilities for controlling consumer message flow, specifically by adding a "drain mode." This mode allows applications to temporarily stop the ingestion of new messages from the Pulsar broker while ensuring that all messages already buffered within the client (both in the application-facing channel and the client's internal queues) can be processed and acknowledged.
+This fork of the official Apache Pulsar Go client introduces enhanced capabilities for controlling consumer message flow, specifically by adding a "drain mode." This mode is designed to help applications manage message consumption more precisely during planned operational scenarios such as dynamic configuration updates for message processing or graceful service shutdowns, especially in horizontally scaled environments.
 
-#### Rationale for Drain Mode
+### Context: Pulsar's Message Ordering and Redelivery
 
-The standard Pulsar Go client's permit-based flow control is designed for continuous consumption. When an application needs to perform certain operations like dynamic configuration changes, maintenance, graceful shutdowns while scaling downespecially in horizontally scaled environments like Kubernetes), it's often desirable to:
+Before detailing the fork's changes, it's important to briefly go over some of Pulsar's baseline message ordering and redelivery characteristics:
 
-1. Stop accepting _new_ messages for a specific consumer or all consumers on a client.
-2. Process and acknowledge all messages that have already been delivered and buffered by the client.
-3. Resume normal consumption after necessary operations are completed or cleanly close the consumer.
+- **Pulsar's Ordering Guarantees**:
 
-The standard client behavior can lead to new messages being fetched as buffered ones are acknowledged due to permit renewal. This fork addresses this by providing explicit control to pause new permit requests during such draining operations.
+  - **Exclusive/Failover Subscriptions**: For a non-partitioned topic or a single partition of a topic, Pulsar guarantees that messages are delivered to the consumer in the same order they were successfully published by the producer. For partitioned topics, the ordering is maintained per partition.
+  - **`Key_Shared` Subscriptions**: This subscription type allows multiple consumers to subscribe to a topic (or its partitions) while ensuring that all messages with the _same message key_ are routed to the _same consumer_. This inherently provides ordered delivery for the sequence of messages associated with a specific key, processed by that designated consumer. Improvements to the `AUTO_SPLIT` mode for `Key_Shared` subscriptions aim to better preserve the order of message delivery for a given key, even when consumers join or leave the group, minimizing disruptions.
 
-#### Benefits of this Enhanced Drain Control
+- **Message Redelivery in Pulsar** Redelivery can occur in several scenarios:
 
-1. **Precise Inflow Stoppage**: Guarantees that no new messages are pulled from the broker while the consumer is in "drain mode", even as buffered messages are acknowledged.
-2. **Complete Processing of Buffered Messages**: Facilitates the full processing of messages already residing in the application's `MessageChannel` and the client's internal `queueCh`.
-3. **Minimized Operational Redeliveries**: By cleanly processing buffered messages before state changes (dynamic reconfiguration, shutdowns), it reduces the chances of messages being NACKed or becoming unacknowledged due to the operation itself, thereby _minimizing operationally-induced redeliveries_. This _supports overall message processing order_ for a given key.
-4. **`Key_Shared` Stickiness Support**: Aims to maintain `Key_Shared` subscription stickiness during the drain period by keeping the underlying connection to the broker alive, even though new message flow is paused. This is particularly important for ensuring keys are not prematurely reassigned during short operational pauses. [Not sure if this is necessary. Will need to test and validate this behavior.]
-5. **Predictable Shutdowns/Updates**: Enables more deterministic behavior during deployments, scaling events, or rule updates in distributed environments.
+  - **Unacknowledged Messages**: If a consumer receives a message but fails to acknowledge it before a configured `ackTimeout` (e.g., due to a consumer crash, prolonged processing, or lost acknowledgment), the broker will make the message available again for delivery, typically to the same consumer if still active, or another available consumer in the subscription.
+  - **Negative Acknowledgements (`Nack`)**: If a consumer explicitly NACKs a message (e.g., due to a temporary inability to process it), the message is scheduled for redelivery by the broker after a configured delay.
+  - **Consumer Seek Operations**: If a consumer uses the `Seek()` API to reset its subscription cursor to an earlier message ID or timestamp, messages from that point onwards will be delivered (or redelivered if they were part of the original stream).
+
+- **Ordering Implications on Redelivery**:
+  - When Pulsar redelivers an individual message, it sends that specific message again.
+  - **Crucially, a redelivered message might arrive out of its original sequence relative to _newly published messages_ for that same key, or relative to other messages in the original sequence that were not redelivered.**
+
+### Purpose and Benefits of This Fork's Drain Mode
+
+The standard Pulsar Go client's permit-based flow control is optimized for continuous message consumption. During planned operational events (like dynamic configuration updates for message processing, or performing a graceful shutdown of a service instance), simply stopping the application from pulling messages can lead to a backlog in client buffers. These buffered messages if not processed in a timely manner may become unacknowledged, leading to them being redelivered by the broker.
+
+This fork introduces an explicit **"drain mode"** to address these scenarios by providing precise control over new message inflow from the broker.
+
+**How the Draining Mechanism Relates and Its Benefits**:
+
+- **Preventing Operational-Induced Redeliveries**: The primary benefit of the drain mode is to **minimize message redeliveries that are a direct consequence of the operational procedure itself** (e.g., dynamic configuration updates, graceful shutdowns, etc.). It does not solve all redelivery scenarios. During such operations, _without controlled draining_ messages residing in client buffers (both the application's `MessageChannel` and the client's internal `queueCh`) might not be fully processed and ACKed, when a consumer is stopped or its processing logic changes mid-flight. These become unacknowledged from the broker's perspective and will be redelivered. _With this fork's `EnterDrainMode()`_:
+  - The application explicitly command the client to stop sending new message permits from the broker, even if buffered messages are being acknowledged.
+  - This allows the application to safely process and acknowledge every message that has already been fetched by the client and is residing in its buffers.
+  - This significantly reduces the pool of messages that would otherwise become unacknowledged (and thus redelivered) due to the shutdown or rule change itself.
+- **Supporting Overall Orderliness for Keyed Messages During Operations**:
+  - By minimizing these operational-induced redeliveries, the drain mode helps maintain the intended processing sequence for messages of a given key _during these planned events_. The main source of potential out-of-order redeliveries then shifts primarily to genuine application failures like NACKs or crashes before ACKs, which **must be handled by the application's idempotent processing logic**.
+
+It's important to understand that this drain mode **does not alter Pulsar's core broker-side behavior for redelivery or ordering**. The fork provides a client-side tool to give the application more control to avoid _causing_ a large set of messages to require redelivery during planned maintenance, updates, or shutdowns.
+
+Beyond addressing redelivery concerns, drain mode provides some operational advantages:
+
+- **Clean Operational Transitions**: Facilitates smoother configuration updates and graceful shutdowns by ensuring all fetched messages are properly processed before the operation transitions.
+- **Resource Management**: Prevents accumulation of unprocessed messages in client buffers during planned pauses, reducing memory pressure and potential message timeout issues.
+- **Key Assignment Stability**: For `Key_Shared` subscriptions, helps maintain key-to-consumer assignments during brief operational windows by keeping connections active while controlling message flow. (The efficacy of this for very long pauses depends on broker configurations regarding inactive-but-connected consumers).
+- **Horizontally Scaled Environments**: Supports more predictable behavior and cleaner state transitions during deployments, scaling events, or rule updates, particularly valuable in containerized or auto-scaled deployments.
+
+The need for **idempotent message processing logic in the application remains absolutely crucial** for robustly handling all types of redelivery scenarios that can occur in a distributed messaging system. This "drain mode" assists in making planned operational procedures smoother and less prone to causing unnecessary redeliveries.

--- a/docs/fork-versions.md
+++ b/docs/fork-versions.md
@@ -1,0 +1,5 @@
+This fork is based on [apache/pulsar-client-go](https://github.com/apache/pulsar-client-go) and follows a versioning scheme that indicates both the base version and our custom modifications:
+
+### Versions
+
+- `v0.15.1-gsl.1`: Based on apache/pulsar-client-go v0.15.1 with drain mode functionality

--- a/examples/consumer-drain-mode/consumer_drain_mode.go
+++ b/examples/consumer-drain-mode/consumer_drain_mode.go
@@ -1,0 +1,270 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/apache/pulsar-client-go/pulsar"
+)
+
+func main() {
+	client, err := pulsar.NewClient(pulsar.ClientOptions{
+		URL: "pulsar://localhost:6650",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+
+	topicName := "drain-mode-example"
+
+	consumer, err := client.Subscribe(pulsar.ConsumerOptions{
+		Topic:             topicName,
+		SubscriptionName:  "drain-example-sub",
+		Type:              pulsar.Shared,
+		ReceiverQueueSize: 20, // Set a reasonable queue size
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer consumer.Close()
+
+	producer, err := client.CreateProducer(pulsar.ProducerOptions{
+		Topic:           topicName,
+		DisableBatching: true, // For more predictable message delivery in this example
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer producer.Close()
+
+	ctx := context.Background()
+
+	var (
+		wg                sync.WaitGroup
+		producerWg        sync.WaitGroup
+		inDrainMode       = false
+		drainModeStarted  = make(chan struct{})
+		drainModeComplete = make(chan struct{})
+		processingDone    = make(chan struct{})
+		messagesMutex     sync.Mutex
+		messagesInBuffer  = make(map[string]bool)
+	)
+
+	// Start consumer goroutine
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		count := 0
+		drainModeProcessedCount := 0
+
+		for {
+			// After processing some messages, enter drain mode
+			if count == 5 && !inDrainMode {
+				inDrainMode = true
+
+				// Record current state of messages that should be in buffer
+				messagesMutex.Lock()
+				fmt.Printf("Entering drain mode - Messages that should be in client buffer when entering drain mode: %d\n", len(messagesInBuffer))
+				messagesMutex.Unlock()
+
+				if err := consumer.EnterDrainMode(); err != nil {
+					log.Printf("Error entering drain mode: %v", err)
+				}
+
+				close(drainModeStarted)
+			}
+
+			msgCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+			msg, err := consumer.Receive(msgCtx)
+			cancel()
+
+			if err != nil {
+				if inDrainMode {
+					// In drain mode, a timeout indicates we've emptied the client buffer
+					messagesMutex.Lock()
+					remainingBuffered := len(messagesInBuffer)
+					messagesMutex.Unlock()
+
+					if remainingBuffered > 0 {
+						fmt.Printf("Drain mode confirmed: Timeout receiving messages while %d are available at broker\n", remainingBuffered)
+					}
+
+					// Only exit drain mode after processing some messages in drain mode
+					if drainModeProcessedCount > 0 && count >= 10 {
+						fmt.Printf("Processed %d messages while in drain mode\n", drainModeProcessedCount)
+
+						messagesMutex.Lock()
+						pendingMessages := len(messagesInBuffer)
+						messagesMutex.Unlock()
+
+						fmt.Printf("Exiting drain mode - Messages still pending at broker (not delivered due to drain mode): %d\n", pendingMessages)
+						if err := consumer.ExitDrainMode(); err != nil {
+							log.Printf("Error exiting drain mode: %v", err)
+						}
+
+						// Signal that we've exited drain mode
+						close(drainModeComplete)
+						inDrainMode = false
+					}
+				} else {
+					fmt.Printf("Receive timed out in normal mode\n")
+				}
+
+				// If we've processed enough messages total, exit the consumer
+				if count >= 25 {
+					fmt.Println("Finished processing all messages, exiting consumer")
+					close(processingDone)
+					return
+				}
+
+				time.Sleep(200 * time.Millisecond)
+				continue
+			}
+
+			// Process the received message
+			payload := string(msg.Payload())
+			count++
+
+			// Remove this message from our tracking of buffered messages
+			messagesMutex.Lock()
+			delete(messagesInBuffer, payload)
+			messagesMutex.Unlock()
+
+			// Track messages processed while in drain mode separately
+			if inDrainMode {
+				drainModeProcessedCount++
+				fmt.Printf("DRAIN MODE - Received from buffer: '%s' (buffer message #%d)\n", payload, drainModeProcessedCount)
+			} else {
+				fmt.Printf("NORMAL MODE - Received: '%s' (total #%d)\n", payload, count)
+			}
+
+			// Acknowledge message
+			consumer.Ack(msg)
+
+			// Simulate message processing time
+			time.Sleep(200 * time.Millisecond)
+		}
+	}()
+
+	// Producer goroutine - sends messages in batches to demonstrate drain mode
+	producerWg.Add(1)
+	go func() {
+		defer producerWg.Done()
+
+		// First batch - send a large batch of messages to fill the client buffer
+		msgCount := 20 // Match our ReceiverQueueSize
+		for i := range msgCount {
+			msgPayload := fmt.Sprintf("message-batch1-%d", i)
+
+			// Track this message as expected to be in client buffer
+			messagesMutex.Lock()
+			messagesInBuffer[msgPayload] = true
+			messagesMutex.Unlock()
+
+			if _, err := producer.Send(ctx, &pulsar.ProducerMessage{
+				Payload: []byte(msgPayload),
+			}); err != nil {
+				log.Fatal(err)
+			}
+			fmt.Printf("Published: %s\n", msgPayload)
+
+			// Small delay between messages
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		// Wait for drain mode to start
+		<-drainModeStarted
+		fmt.Println("Consumer entered drain mode")
+
+		time.Sleep(1 * time.Second)
+
+		// Send more messages while consumer is in drain mode
+		drainBatchSize := 15
+
+		for i := range drainBatchSize {
+			msgPayload := fmt.Sprintf("drain-mode-msg-%d", i)
+
+			// Track messages sent during drain mode
+			messagesMutex.Lock()
+			messagesInBuffer[msgPayload] = true
+			messagesMutex.Unlock()
+
+			if _, err := producer.Send(ctx, &pulsar.ProducerMessage{
+				Payload: []byte(msgPayload),
+			}); err != nil {
+				log.Fatal(err)
+			}
+			fmt.Printf("Published while in drain mode: %s\n", msgPayload)
+
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		// Wait for consumer to exit drain mode
+		<-drainModeComplete
+		fmt.Println("Consumer exited drain mode")
+
+		// Send a final batch of messages after drain mode
+		finalBatchSize := 5
+		for i := range finalBatchSize {
+			msgPayload := fmt.Sprintf("after-drain-msg-%d", i)
+
+			messagesMutex.Lock()
+			messagesInBuffer[msgPayload] = true
+			messagesMutex.Unlock()
+
+			if _, err := producer.Send(ctx, &pulsar.ProducerMessage{
+				Payload: []byte(msgPayload),
+			}); err != nil {
+				log.Fatal(err)
+			}
+			fmt.Printf("Published after drain mode: %s\n", msgPayload)
+
+			time.Sleep(100 * time.Millisecond)
+		}
+	}()
+
+	select {
+	case <-processingDone:
+		messagesMutex.Lock()
+		undeliveredCount := len(messagesInBuffer)
+		messagesMutex.Unlock()
+
+		if undeliveredCount > 0 {
+			fmt.Printf("Warning: %d messages were produced but not consumed\n", undeliveredCount)
+		} else {
+			fmt.Println("Successfully processed all produced messages!")
+		}
+
+	case <-time.After(30 * time.Second):
+		fmt.Println("Example timed out")
+
+		messagesMutex.Lock()
+		fmt.Printf("There are %d messages that were produced but not consumed\n", len(messagesInBuffer))
+		messagesMutex.Unlock()
+	}
+
+	producerWg.Wait()
+	wg.Wait()
+
+}

--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -393,4 +393,13 @@ type Consumer interface {
 
 	// Name returns the name of consumer.
 	Name() string
+
+	// EnterDrainMode stops sending permit flow requests to the broker, preventing
+	// delivery of any new messages while allowing the consumer to process existing
+	// messages in the client buffer.
+	EnterDrainMode() error
+
+	// ExitDrainMode resumes normal message flow by allowing the consumer to send
+	// permit flow requests to the broker for new message delivery.
+	ExitDrainMode() error
 }

--- a/pulsar/consumer_drain_test.go
+++ b/pulsar/consumer_drain_test.go
@@ -1,0 +1,313 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/apache/pulsar-client-go/pulsar/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConsumerDrainMode(t *testing.T) {
+	sLogger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	client, err := NewClient(ClientOptions{
+		URL:    lookupURL,
+		Logger: log.NewLoggerWithSlog(sLogger),
+	})
+	assert.Nil(t, err)
+	defer client.Close()
+
+	topicName := fmt.Sprintf("consumer-drain-mode-test-%v", time.Now().UnixNano())
+	ctx := context.Background()
+
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:           topicName,
+		DisableBatching: false,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	queueSize := 4
+	messageChanSize := 10
+	totalBufferCapacity := queueSize + messageChanSize
+
+	consumer, err := client.Subscribe(ConsumerOptions{
+		Topic:             topicName,
+		SubscriptionName:  "drain-mode-sub",
+		Type:              Shared,
+		ReceiverQueueSize: queueSize, // queueCh size is set to ReceiverQueueSize
+		// Note: messageCh capacity is hardcoded to 10 in the client implementation
+	})
+	assert.Nil(t, err)
+	defer consumer.Close()
+
+	// Phase 1: Produce initial messages
+	initialMessages := 40
+	for i := range initialMessages {
+		_, err := producer.Send(ctx, &ProducerMessage{
+			Payload: fmt.Appendf(nil, "normal-msg-%d", i),
+		})
+		assert.Nil(t, err)
+	}
+
+	// Give some time for messages to be delivered to broker and initial permits to be received
+	// This ensures the client buffers are filled
+	time.Sleep(500 * time.Millisecond)
+
+	// Phase 2: Enter drain mode before consuming any messages
+	err = consumer.EnterDrainMode()
+	assert.Nil(t, err)
+
+	// Consume messages from the buffers while in drain mode
+	// We expect to receive exactly totalBufferCapacity messages
+	drainModeMessages := make([]string, 0, totalBufferCapacity)
+
+	// Consume messages with a timeout to get all buffered messages
+	drainTimeout := 5 * time.Second
+	startTime := time.Now()
+
+	for time.Since(startTime) < drainTimeout {
+		receiveCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		msg, err := consumer.Receive(receiveCtx)
+		cancel()
+
+		if err != nil {
+			// No more messages to receive
+			break
+		}
+
+		payload := string(msg.Payload())
+		drainModeMessages = append(drainModeMessages, payload)
+		// t.Logf("Received from buffer in drain mode (%d/%d expected): %s",
+		// 	len(drainModeMessages), totalBufferCapacity, payload)
+		consumer.Ack(msg)
+	}
+
+	// Verify we received exactly the expected number of messages
+	// t.Logf("Received %d messages from buffer while in drain mode", len(drainModeMessages))
+	assert.Equal(t, totalBufferCapacity, len(drainModeMessages),
+		"Should receive exactly %d messages from buffer in drain mode", totalBufferCapacity)
+
+	// Phase 3: Send new messages while in drain mode and verify they aren't received
+	drainModeProducedCount := 20
+	for i := range drainModeProducedCount {
+		_, err := producer.Send(ctx, &ProducerMessage{
+			Payload: fmt.Appendf(nil, "drain-produced-msg-%d", i),
+		})
+		assert.Nil(t, err)
+	}
+
+	// Wait a bit to ensure messages have reached the broker
+	time.Sleep(1 * time.Second)
+
+	// Try to receive more messages - should time out as no new messages should be delivered in drain mode
+	// t.Log("Verifying no new messages are received while in drain mode")
+	receiveCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	_, err = consumer.Receive(receiveCtx)
+	cancel()
+
+	// We should timeout since the broker should not deliver new messages in drain mode
+	assert.NotNil(t, err, "Should timeout as no new messages should be delivered in drain mode")
+	t.Logf("Successfully confirmed no new messages while in drain mode: %v", err)
+
+	// Phase 4: Exit drain mode and verify new messages start flowing
+	// t.Log("Phase 4: Exiting drain mode and verifying message flow resumes")
+	err = consumer.ExitDrainMode()
+	assert.Nil(t, err)
+
+	// Now we should receive some of the previously produced messages
+	// Let's verify we receive at least minExpected messages after exiting drain mode
+	minExpected := initialMessages + drainModeProducedCount - totalBufferCapacity
+	messagesAfterDrain := make([]string, 0, minExpected)
+
+	// Give some time for permits to be received and messages to be delivered
+	time.Sleep(1 * time.Second)
+
+	// t.Logf("Expecting to receive at least %d messages after exiting drain mode", minExpected)
+	for range minExpected {
+		receiveCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		msg, err := consumer.Receive(receiveCtx)
+		cancel()
+
+		if err != nil {
+			// t.Logf("Failed to receive message after drain mode (%d/%d): %v",
+			// 	len(messagesAfterDrain), minExpected, err)
+			break
+		}
+
+		payload := string(msg.Payload())
+		messagesAfterDrain = append(messagesAfterDrain, payload)
+		// t.Logf("Received after exiting drain mode (%d/%d): %s",
+		// 	len(messagesAfterDrain), minExpected, payload)
+		consumer.Ack(msg)
+	}
+
+	// Verify we received at least the minimum expected messages after exiting drain mode
+	assert.GreaterOrEqual(t, len(messagesAfterDrain), minExpected,
+		"Should receive at least %d messages after exiting drain mode", minExpected)
+	// t.Logf("Received %d messages after exiting drain mode", len(messagesAfterDrain))
+
+	// Final verification
+	// t.Log("Test completed successfully, drain mode behavior verified")
+}
+
+func TestConsumerBufferDrainMode(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+	assert.Nil(t, err)
+	defer client.Close()
+
+	topicName := fmt.Sprintf("consumer-buffer-drain-test-%v", time.Now().UnixNano())
+	ctx := context.Background()
+
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:           topicName,
+		DisableBatching: false,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	queueSize := 20
+	messageChanSize := 10
+	totalBufferCapacity := queueSize + messageChanSize
+
+	consumer, err := client.Subscribe(ConsumerOptions{
+		Topic:             topicName,
+		SubscriptionName:  "buffer-drain-sub",
+		Type:              Shared,
+		ReceiverQueueSize: queueSize,
+	})
+	assert.Nil(t, err)
+	defer consumer.Close()
+
+	messageCount := 40
+	for i := range messageCount {
+		_, err := producer.Send(ctx, &ProducerMessage{
+			Payload: fmt.Appendf(nil, "buffer-msg-%d", i),
+		})
+		assert.Nil(t, err)
+	}
+
+	// Give some time for messages to be delivered to client buffer
+	time.Sleep(1 * time.Second)
+
+	// Enter drain mode before receiving any messages
+	err = consumer.EnterDrainMode()
+	assert.Nil(t, err)
+
+	// Now consume messages from the client buffer while in drain mode
+	// We expect to receive exactly totalBufferCapacity messages
+	messagesInBuffer := make([]string, 0, totalBufferCapacity)
+	drainTimeout := 5 * time.Second
+	startTime := time.Now()
+
+	// Keep receiving messages until we get the expected count or timeout
+	for len(messagesInBuffer) < totalBufferCapacity && time.Since(startTime) < drainTimeout {
+		receiveCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		msg, err := consumer.Receive(receiveCtx)
+		cancel()
+
+		if err != nil {
+			t.Logf("Received error after %d messages: %v", len(messagesInBuffer), err)
+			break
+		}
+
+		payload := string(msg.Payload())
+		messagesInBuffer = append(messagesInBuffer, payload)
+		t.Logf("Received from buffer in drain mode (%d/%d expected): %s",
+			len(messagesInBuffer), totalBufferCapacity, payload)
+		consumer.Ack(msg)
+	}
+
+	// Verify we received exactly the expected number of messages
+	assert.Equal(t, totalBufferCapacity, len(messagesInBuffer),
+		"Should receive exactly %d messages from buffer in drain mode", totalBufferCapacity)
+
+	// Try to receive more messages - should time out since we're in drain mode and buffer is emptied
+	// t.Log("Verifying no more messages come through after buffer is emptied")
+	receiveCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	_, err = consumer.Receive(receiveCtx)
+	cancel()
+	assert.NotNil(t, err, "Should timeout as no new messages should be delivered in drain mode")
+
+	// Produce more messages while in drain mode
+	moreMessageCount := 15
+	for i := range moreMessageCount {
+		_, err := producer.Send(ctx, &ProducerMessage{
+			Payload: fmt.Appendf(nil, "after-drain-msg-%d", i),
+		})
+		assert.Nil(t, err)
+	}
+
+	// Verify we can't receive these messages while in drain mode
+	receiveCtx2, cancel2 := context.WithTimeout(ctx, 2*time.Second)
+	_, err = consumer.Receive(receiveCtx2)
+	cancel2()
+	assert.NotNil(t, err, "Should timeout as no new messages should be delivered in drain mode")
+	// t.Logf("Successfully confirmed no new messages while in drain mode: %v", err)
+
+	// Now exit drain mode and verify we get more messages
+	// t.Log("Exiting drain mode to verify normal message flow resumes")
+	err = consumer.ExitDrainMode()
+	assert.Nil(t, err)
+
+	// Give some time for permits to be received and messages to be delivered
+	time.Sleep(1 * time.Second)
+
+	// Try to receive messages after exiting drain mode
+	// We expect to receive at least some minimum number of the messages we sent during drain mode
+	minExpected := messageCount + moreMessageCount - totalBufferCapacity
+	messagesAfterDrain := make([]string, 0, minExpected)
+
+	for range minExpected {
+		receiveCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		msg, err := consumer.Receive(receiveCtx)
+		cancel()
+
+		if err != nil {
+			// t.Logf("Error receiving message after drain mode: %v", err)
+			break
+		}
+
+		payload := string(msg.Payload())
+		messagesAfterDrain = append(messagesAfterDrain, payload)
+		// t.Logf("Received after drain mode (%d/%d minimum): %s",
+		// 	len(messagesAfterDrain), minExpected, payload)
+		consumer.Ack(msg)
+
+		// Once we've received the minimum required count, we can stop
+		if len(messagesAfterDrain) >= minExpected {
+			break
+		}
+	}
+
+	// Verify we received at least the minimum expected messages after exiting drain mode
+	assert.GreaterOrEqual(t, len(messagesAfterDrain), minExpected,
+		"Should receive at least %d messages after exiting drain mode", minExpected)
+	t.Logf("Received %d messages after exiting drain mode", len(messagesAfterDrain))
+
+	// t.Log("Buffer drain test completed successfully")
+}

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -483,6 +483,38 @@ func (c *consumer) UnsubscribeForce() error {
 	return c.unsubscribe(true)
 }
 
+func (c *consumer) EnterDrainMode() error {
+	c.Lock()
+	defer c.Unlock()
+
+	var errMsg string
+	for _, consumer := range c.consumers {
+		if err := consumer.enterInternalDrainMode(); err != nil {
+			errMsg += fmt.Sprintf("topic %s, subscription %s: %s; ", consumer.topic, c.Subscription(), err)
+		}
+	}
+	if errMsg != "" {
+		return errors.New(errMsg)
+	}
+	return nil
+}
+
+func (c *consumer) ExitDrainMode() error {
+	c.Lock()
+	defer c.Unlock()
+
+	var errMsg string
+	for _, consumer := range c.consumers {
+		if err := consumer.exitInternalDrainMode(); err != nil {
+			errMsg += fmt.Sprintf("topic %s, subscription %s: %s; ", consumer.topic, c.Subscription(), err)
+		}
+	}
+	if errMsg != "" {
+		return errors.New(errMsg)
+	}
+	return nil
+}
+
 func (c *consumer) unsubscribe(force bool) error {
 	c.Lock()
 	defer c.Unlock()

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -97,6 +97,30 @@ func (c *multiTopicConsumer) Unsubscribe() error {
 	return errs
 }
 
+func (c *multiTopicConsumer) EnterDrainMode() error {
+	var errs error
+	for t, consumer := range c.consumers {
+		if err := consumer.EnterDrainMode(); err != nil {
+			msg := fmt.Sprintf("unable to enter drain mode for topic=%s subscription=%s",
+				t, c.Subscription())
+			errs = pkgerrors.Wrap(err, msg)
+		}
+	}
+	return errs
+}
+
+func (c *multiTopicConsumer) ExitDrainMode() error {
+	var errs error
+	for t, consumer := range c.consumers {
+		if err := consumer.ExitDrainMode(); err != nil {
+			msg := fmt.Sprintf("unable to exit drain mode for topic=%s subscription=%s",
+				t, c.Subscription())
+			errs = pkgerrors.Wrap(err, msg)
+		}
+	}
+	return errs
+}
+
 func (c *multiTopicConsumer) UnsubscribeForce() error {
 	var errs error
 	for t, consumer := range c.consumers {

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -255,6 +255,11 @@ func (p *availablePermits) get() int32 {
 }
 
 func (p *availablePermits) flowIfNeed() {
+	// If in drain mode, don't request more permits to broker
+	if p.pc.isDrainingNoNewPermits.Load() {
+		p.pc.log.Debug("In drain mode - not requesting more permits from broker")
+		return
+	}
 	// TODO implement a better flow controller
 	// send more permits if needed
 	var flowThreshold int32
@@ -266,11 +271,6 @@ func (p *availablePermits) flowIfNeed() {
 
 	current := p.get()
 	if current >= flowThreshold {
-		// If in drain mode, don't request more permits to broker
-		if p.pc.isDrainingNoNewPermits.Load() {
-			p.pc.log.Debug("In drain mode - not requesting more permits from broker")
-			return
-		}
 
 		availablePermits := current
 		requestedPermits := current

--- a/pulsar/consumer_partition.go
+++ b/pulsar/consumer_partition.go
@@ -201,6 +201,10 @@ type partitionConsumer struct {
 	hasSoughtByTime atomic.Bool
 	ctx             context.Context
 	cancelFunc      context.CancelFunc
+
+	// When true, the consumer is in "drain mode" and will not send new permit flow requests to the broker.
+	// This allows processing of already-delivered messages without receiving new ones.
+	isDrainingNoNewPermits atomic.Bool
 }
 
 // pauseDispatchMessage used to discard the message in the dispatcher goroutine.
@@ -262,6 +266,12 @@ func (p *availablePermits) flowIfNeed() {
 
 	current := p.get()
 	if current >= flowThreshold {
+		// If in drain mode, don't request more permits to broker
+		if p.pc.isDrainingNoNewPermits.Load() {
+			p.pc.log.Debug("In drain mode - not requesting more permits from broker")
+			return
+		}
+
 		availablePermits := current
 		requestedPermits := current
 		// check if permits changed

--- a/pulsar/consumer_partition_drain.go
+++ b/pulsar/consumer_partition_drain.go
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"errors"
+)
+
+// enterInternalDrainMode puts the partition consumer into drain mode
+func (pc *partitionConsumer) enterInternalDrainMode() error {
+	if state := pc.getConsumerState(); state == consumerClosed || state == consumerClosing {
+		pc.log.WithField("state", state).Error("Failed to enter drain mode: consumer closing or closed")
+		return errors.New("consumer closing or closed")
+	}
+
+	wasAlreadyDraining := pc.isDrainingNoNewPermits.Swap(true)
+	if wasAlreadyDraining {
+		pc.log.Debug("Consumer was already in drain mode")
+		return nil
+	}
+
+	if pc.metrics != nil {
+		pc.metrics.ConsumersInDrainMode.Inc()
+		pc.metrics.DrainModeEntered.Inc()
+	}
+
+	pc.log.Info("Consumer entered drain mode - no new messages will be fetched from broker")
+	return nil
+}
+
+// exitInternalDrainMode takes the partition consumer out of drain mode
+func (pc *partitionConsumer) exitInternalDrainMode() error {
+	if state := pc.getConsumerState(); state == consumerClosed || state == consumerClosing {
+		pc.log.WithField("state", state).Error("Failed to exit drain mode: consumer closing or closed")
+		return errors.New("consumer closing or closed")
+	}
+
+	wasDraining := pc.isDrainingNoNewPermits.Swap(false)
+	if !wasDraining {
+		pc.log.Debug("Consumer was not in drain mode")
+		return nil
+	}
+
+	if pc.metrics != nil {
+		pc.metrics.ConsumersInDrainMode.Dec()
+		pc.metrics.DrainModeExited.Inc()
+	}
+
+	// Trigger permit flow to resume message delivery if there are available permits
+	pc.availablePermits.flowIfNeed()
+
+	pc.log.Info("Consumer exited drain mode - normal message flow resumed")
+	return nil
+}

--- a/pulsar/consumer_regex_drain.go
+++ b/pulsar/consumer_regex_drain.go
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"errors"
+	"fmt"
+)
+
+func (c *regexConsumer) EnterDrainMode() error {
+	c.consumersLock.Lock()
+	defer c.consumersLock.Unlock()
+
+	var errMsg string
+	if c.closed() {
+		return errors.New("regex consumer already closed")
+	}
+
+	for topic, consumer := range c.consumers {
+		if consumerWithDrain, ok := consumer.(interface {
+			EnterDrainMode() error
+		}); ok {
+			if err := consumerWithDrain.EnterDrainMode(); err != nil {
+				errMsg += fmt.Sprintf("topic %s: %s; ", topic, err.Error())
+			}
+		} else {
+			errMsg += fmt.Sprintf("topic %s: consumer does not support drain mode; ", topic)
+		}
+	}
+
+	if errMsg != "" {
+		return errors.New(errMsg)
+	}
+	return nil
+}
+
+func (c *regexConsumer) ExitDrainMode() error {
+	c.consumersLock.Lock()
+	defer c.consumersLock.Unlock()
+
+	var errMsg string
+	if c.closed() {
+		return errors.New("regex consumer already closed")
+	}
+
+	for topic, consumer := range c.consumers {
+		if consumerWithDrain, ok := consumer.(interface {
+			ExitDrainMode() error
+		}); ok {
+			if err := consumerWithDrain.ExitDrainMode(); err != nil {
+				errMsg += fmt.Sprintf("topic %s: %s; ", topic, err.Error())
+			}
+		} else {
+			errMsg += fmt.Sprintf("topic %s: consumer does not support drain mode; ", topic)
+		}
+	}
+
+	if errMsg != "" {
+		return errors.New(errMsg)
+	}
+	return nil
+}

--- a/pulsar/consumer_zero_queue.go
+++ b/pulsar/consumer_zero_queue.go
@@ -288,6 +288,20 @@ func (z *zeroQueueConsumer) SeekByTime(time time.Time) error {
 	return errs
 }
 
+func (z *zeroQueueConsumer) EnterDrainMode() error {
+	z.Lock()
+	defer z.Unlock()
+
+	return z.pc.enterInternalDrainMode()
+}
+
+func (z *zeroQueueConsumer) ExitDrainMode() error {
+	z.Lock()
+	defer z.Unlock()
+
+	return z.pc.exitInternalDrainMode()
+}
+
 func (z *zeroQueueConsumer) Name() string {
 	return z.consumerName
 }

--- a/pulsar/internal/metrics.go
+++ b/pulsar/internal/metrics.go
@@ -53,6 +53,10 @@ type Metrics struct {
 	readersOpened              *prometheus.CounterVec
 	readersClosed              *prometheus.CounterVec
 
+	consumersInDrainMode *prometheus.GaugeVec
+	drainModeEntered     *prometheus.CounterVec
+	drainModeExited      *prometheus.CounterVec
+
 	// Metrics that are not labeled with specificity are immediately available
 	ConnectionsOpened                     prometheus.Counter
 	ConnectionsClosed                     prometheus.Counter
@@ -81,6 +85,10 @@ type LeveledMetrics struct {
 	NacksCounter       prometheus.Counter
 	DlqCounter         prometheus.Counter
 	ProcessingTime     prometheus.Observer
+
+	ConsumersInDrainMode prometheus.Gauge
+	DrainModeEntered     prometheus.Counter
+	DrainModeExited      prometheus.Counter
 
 	ProducersOpened            prometheus.Counter
 	ProducersClosed            prometheus.Counter
@@ -132,6 +140,25 @@ func NewMetricsProvider(metricsCardinality int, userDefinedLabels map[string]str
 		bytesPublished: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name:        "pulsar_client_bytes_published",
 			Help:        "Counter of messages published by the client",
+			ConstLabels: constLabels,
+		}, metricsLevelLabels),
+
+		// Drain mode metrics
+		consumersInDrainMode: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        "pulsar_client_consumers_in_drain_mode",
+			Help:        "Number of consumers currently in drain mode",
+			ConstLabels: constLabels,
+		}, metricsLevelLabels),
+
+		drainModeEntered: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name:        "pulsar_client_drain_mode_entered",
+			Help:        "Counter of drain mode entered events",
+			ConstLabels: constLabels,
+		}, metricsLevelLabels),
+
+		drainModeExited: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name:        "pulsar_client_drain_mode_exited",
+			Help:        "Counter of drain mode exited events",
 			ConstLabels: constLabels,
 		}, metricsLevelLabels),
 
@@ -353,6 +380,28 @@ func NewMetricsProvider(metricsCardinality int, userDefinedLabels map[string]str
 	if err != nil {
 		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
 			metrics.bytesPending = are.ExistingCollector.(*prometheus.GaugeVec)
+		}
+	}
+
+	// Register drain mode metrics
+	err = registerer.Register(metrics.consumersInDrainMode)
+	if err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			metrics.consumersInDrainMode = are.ExistingCollector.(*prometheus.GaugeVec)
+		}
+	}
+
+	err = registerer.Register(metrics.drainModeEntered)
+	if err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			metrics.drainModeEntered = are.ExistingCollector.(*prometheus.CounterVec)
+		}
+	}
+
+	err = registerer.Register(metrics.drainModeExited)
+	if err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			metrics.drainModeExited = are.ExistingCollector.(*prometheus.CounterVec)
 		}
 	}
 	err = registerer.Register(metrics.publishErrors)
@@ -585,6 +634,9 @@ func (mp *Metrics) GetLeveledMetrics(t string) *LeveledMetrics {
 		ConsumersReconnectFailure:  mp.consumersReconnectFailure.With(labels),
 		ConsumersReconnectMaxRetry: mp.consumersReconnectMaxRetry.With(labels),
 		ConsumersPartitions:        mp.consumersPartitions.With(labels),
+		ConsumersInDrainMode:       mp.consumersInDrainMode.With(labels),
+		DrainModeEntered:           mp.drainModeEntered.With(labels),
+		DrainModeExited:            mp.drainModeExited.With(labels),
 		ReadersOpened:              mp.readersOpened.With(labels),
 		ReadersClosed:              mp.readersClosed.With(labels),
 	}

--- a/pulsar/internal/pulsartracing/consumer_interceptor_test.go
+++ b/pulsar/internal/pulsartracing/consumer_interceptor_test.go
@@ -119,3 +119,11 @@ func (c *mockConsumer) GetLastMessageIDs() ([]pulsar.TopicMessageID, error) {
 	ids := make([]pulsar.TopicMessageID, 0)
 	return ids, nil
 }
+
+func (c *mockConsumer) EnterDrainMode() error {
+	return nil
+}
+
+func (c *mockConsumer) ExitDrainMode() error {
+	return nil
+}

--- a/pulsar/reader.go
+++ b/pulsar/reader.go
@@ -140,4 +140,13 @@ type Reader interface {
 	// GetLastMessageID get the last message id available for consume.
 	// It only works for single topic reader. It will return an error when the reader is the multi-topic reader.
 	GetLastMessageID() (MessageID, error)
+
+	// EnterDrainMode stops sending permit flow requests to the broker, preventing
+	// delivery of any new messages while allowing the reader to process existing
+	// messages in the client buffer.
+	EnterDrainMode() error
+
+	// ExitDrainMode resumes normal message flow by allowing the reader to send
+	// permit flow requests to the broker for new message delivery.
+	ExitDrainMode() error
 }

--- a/pulsar/reader_impl.go
+++ b/pulsar/reader_impl.go
@@ -223,6 +223,20 @@ func (r *reader) SeekByTime(time time.Time) error {
 	return r.c.SeekByTime(time)
 }
 
+func (r *reader) EnterDrainMode() error {
+	r.Lock()
+	defer r.Unlock()
+
+	return r.c.EnterDrainMode()
+}
+
+func (r *reader) ExitDrainMode() error {
+	r.Lock()
+	defer r.Unlock()
+
+	return r.c.ExitDrainMode()
+}
+
 func (r *reader) GetLastMessageID() (MessageID, error) {
 	if len(r.c.consumers) > 1 {
 		return nil, fmt.Errorf("GetLastMessageID is not supported for multi-topics reader")


### PR DESCRIPTION
### Motivation

Client applications often need to gracefully drain their message processing buffers during operational tasks like configuration updates or service shutdowns. The current implementation doesn't allow consumers to stop receiving new messages while still processing already delivered ones.

This is particularly important for applications using Key_Shared subscriptions where consumer topology changes can affect key assignments, and for horizontally scaled applications that need to perform rolling updates without message loss.

### Modifications

- Added `EnterDrainMode()` and `ExitDrainMode()` methods to the Consumer interface
- Modified flow control logic to prevent requesting new permits when in drain mode
- Added internal state tracking for the drain mode state
- Added metrics to track drain mode status and transitions
- Added comprehensive tests for drain mode behavior verification 
- Added example applications demonstrating common drain mode usage patterns
- Added detailed documentation in CONSUMER_DRAIN_CONTROL.md

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:
- Added unit tests in `consumer_drain_test.go` to verify the drain mode functionality
- Added example applications in `examples/consumer-drain-mode` showing usage

### Does this pull request potentially affect one of the following parts:

- Dependencies: no
- The public API: yes (adds new methods to Consumer interface)
- The schema: no
- The default values of configurations: no
- The wire protocol: no (uses existing flow control mechanisms)

### Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? docs
- Added comprehensive documentation in CONSUMER_DRAIN_CONTROL.md
- Added example applications demonstrating usage
- Added inline documentation in interfaces and implementations